### PR TITLE
Fix unnamed append points

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -453,8 +453,8 @@ class ConfigFile(object):
 
 			# Check if we need to slice into the array to insert
 			try:
-				compiled = self.insert_at_ap(content, single_file)
-			except:
+				compiled = self.insert_at_ap(compiled, single_file)
+			except ValueError:
 				compiled += ['\n'] + single_file
 
 		# Handle merging in the named append points


### PR DESCRIPTION
In `ConfigFile.compile()`, the variable `content` is used but not
initialized, which results in unnamed append points being deleted and
`insert_lines` being appended at the end instead. Due to the
undifferentiated `try/except` block around this, the error is silently
ignored.

This fix makes the `try/except` block only handle `ValueError`, which
would occur when there's no explicit append point.
