### PR TITLE
Add missing parameters to handle_warning()

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -163,7 +163,7 @@ def handle_exception(exc_type, value, trace):
 sys.excepthook = handle_exception
 
 # Globaly handle warnings in a clean way
-def handle_warning(message, category, filename, line):
+def handle_warning(message, category, filename, lineno, file=None, line=None):
     sys.stderr.write("\033[93m{}: {}\033[0m\n".format(category.__name__, message))
 
 warnings.showwarning = handle_warning


### PR DESCRIPTION
Without the fix warnings fail with:

    handle_warning() takes 4 positional arguments but 6 were given

Respective documentation:
* https://docs.python.org/2/library/warnings.html#warnings.showwarning
* https://docs.python.org/3/library/warnings.html#warnings.showwarning